### PR TITLE
Additional zig16 fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ fn update_step(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
             .branch = "main",
         },
     };
-    try update.update_dependency(step.owner.allocator, deps);
+    try update.update_dependency(step.owner.allocator, step.owner.graph.io, deps);
 }
 
 pub fn build(b: *std.Build) void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -12,7 +12,7 @@ pub const tvg_from_svg = conversion.tvg_from_svg;
 
 pub const Color = tvg.Color;
 
-test "coverage" {
+test "Typecheck everything" {
+    // Force the compiler to typecheck these modules
     _ = .{ tvg_from_svg, renderStream, rendering, conversion };
-    std.log.warn("ok", .{});
 }

--- a/src/tinyvg/builder.zig
+++ b/src/tinyvg/builder.zig
@@ -427,9 +427,9 @@ const ReducedCount = enum(u6) {
 
 test "encode app_menu (default range, scale 1/256)" {
     var buffer: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buffer);
+    const fixed: std.Io.Writer = .fixed(&buffer);
 
-    var writer = create(stream.writer());
+    var writer: Builder(std.Io.Writer) = create(fixed);
     try writer.writeHeader(48, 48, .@"1/256", .u8888, .default);
     try writer.writeColorTable(&[_]tvg.Color{
         try tvg.Color.fromString("000000"),
@@ -444,9 +444,9 @@ test "encode app_menu (default range, scale 1/256)" {
 
 test "encode workspace (default range, scale 1/256)" {
     var buffer: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buffer);
+    const fixed: std.Io.Writer = .fixed(&buffer);
 
-    var writer = create(stream.writer());
+    var writer: Builder(std.Io.Writer) = create(fixed);
     try writer.writeHeader(48, 48, .@"1/256", .u8888, .default);
     try writer.writeColorTable(&[_]tvg.Color{
         try tvg.Color.fromString("008751"),
@@ -464,9 +464,9 @@ test "encode workspace_add (default range, scale 1/256)" {
     const Node = tvg.Path.Node;
 
     var buffer: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buffer);
+    const fixed: std.Io.Writer = .fixed(&buffer);
 
-    var writer = create(stream.writer());
+    var writer: Builder(std.Io.Writer) = create(fixed);
     try writer.writeHeader(48, 48, .@"1/256", .u8888, .default);
     try writer.writeColorTable(&[_]tvg.Color{
         try tvg.Color.fromString("008751"),
@@ -503,9 +503,9 @@ test "encode arc_variants (default range, scale 1/256)" {
     const Node = tvg.Path.Node;
 
     var buffer: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buffer);
+    const fixed: std.Io.Writer = .fixed(&buffer);
 
-    var writer = create(stream.writer());
+    var writer: Builder(std.Io.Writer) = create(fixed);
     try writer.writeHeader(92, 92, .@"1/256", .u8888, .default);
     try writer.writeColorTable(&[_]tvg.Color{
         try tvg.Color.fromString("40ff00"),

--- a/update.zig
+++ b/update.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const Io = std.Io;
 const Child = std.process.Child;
 
 /// url must be something like: https://github.com/nat3Github/zig-lib-dvui-dev-fork
 ///  branch must be something like main or dev
-pub fn get_hash(alloc: Allocator, url: []const u8, branch: []const u8) ![]const u8 {
+pub fn get_hash(alloc: Allocator, io: Io, url: []const u8, branch: []const u8) ![]const u8 {
     const get_commit = &.{ "git", "ls-remote", url };
-    const dat = try exec(alloc, get_commit);
+    const dat = try exec(alloc, io, get_commit);
     var tokenizer = std.mem.tokenizeAny(u8, dat, "\r\n");
     var hash: []const u8 = "";
     const refs_heads = "refs/heads/";
@@ -28,8 +29,8 @@ pub fn get_hash(alloc: Allocator, url: []const u8, branch: []const u8) ![]const 
     return error.BranchNotFound;
 }
 
-pub fn get_zig_fetch_repo_string(alloc: Allocator, url: []const u8, branch: []const u8) ![]const u8 {
-    const hash = try get_hash(alloc, url, branch);
+pub fn get_zig_fetch_repo_string(alloc: Allocator, io: Io, url: []const u8, branch: []const u8) ![]const u8 {
+    const hash = try get_hash(alloc, io, url, branch);
     const repo = try std.fmt.allocPrint(alloc, "git+{s}#{s}", .{ url, hash });
     return repo;
 }
@@ -39,11 +40,11 @@ pub const GitDependency = struct {
     branch: []const u8,
 };
 
-pub fn update_dependency(alloc: Allocator, deps: []const GitDependency) !void {
+pub fn update_dependency(alloc: Allocator, io: Io, deps: []const GitDependency) !void {
     for (deps) |dep| {
-        const rep = try get_zig_fetch_repo_string(alloc, dep.url, dep.branch);
+        const rep = try get_zig_fetch_repo_string(alloc, io, dep.url, dep.branch);
         std.log.info("running zig fetch --save {s}", .{rep});
-        _ = try exec(alloc, &.{
+        _ = try exec(alloc, io, &.{
             "zig",
             "fetch",
             "--save",
@@ -52,7 +53,7 @@ pub fn update_dependency(alloc: Allocator, deps: []const GitDependency) !void {
     }
     std.log.info("ok", .{});
 }
-pub fn exec(alloc: Allocator, args: []const []const u8) ![]const u8 {
+pub fn exec(alloc: Allocator, io: Io, args: []const []const u8) ![]const u8 {
     var caller = Child.init(args, alloc);
     caller.stdout_behavior = .Pipe;
     caller.stderr_behavior = .Pipe;
@@ -60,9 +61,9 @@ pub fn exec(alloc: Allocator, args: []const []const u8) ![]const u8 {
     var stderr = std.ArrayListUnmanaged(u8){};
     errdefer stdout.deinit(alloc);
     defer stderr.deinit(alloc);
-    try caller.spawn();
+    try caller.spawn(io);
     try caller.collectOutput(alloc, &stdout, &stderr, 1024 * 1024);
-    const res = try caller.wait();
+    const res = try caller.wait(io);
     if (res.Exited > 0) {
         std.log.err("{s}\n", .{stderr.items});
         return error.Failed;


### PR DESCRIPTION
I was looking to use this package with zig 0.16 and noticed a few remaining issues. This PR fixes deprecated io usage in builder.zig and update.zig. 

There was also a weird issue (on windows 10, if that's relevant) where `zig build test` output some strange noise before the test results:
```bash
$ zig build test
test
└─ run test w
[default] (warn): ok
failed command: "C:\\Users\\mdm59\\Documents\\work\\programming\\zig-lib-svg2tvg\\.zig-cache\\o\\bc18
32a9c44dc55152795914d32611ec\\test.exe" "--cache-dir=C:\\Users\\mdm59\\Documents\\work\\programming\\
zig-lib-svg2tvg\\.zig-cache" --seed=0x83801905 --listen=-
```

The tests here actually all pass, but it was outputting some garbage. I traced this to the root.zig call to `std.log.warn`, and removing that call removed the erroring output.

With these changes, the tests passed and everything builds OK on my machine using master